### PR TITLE
Update affected version of CVE-2021-3130. Minor text update.

### DIFF
--- a/CVE-2021-3130
+++ b/CVE-2021-3130
@@ -3,7 +3,7 @@ CVE-2021-3130
 
 [Suggested description]
 
-Within the Open-AudIT up to 4.0.2 application, the web interface hides SSH secrets, Windows passwords, and SNMP strings from users using HTML 'password field' obfuscation. By using Developer tools or similar, it is possible to change the obfuscation so that the credentials are visible.
+Within the Open-AudIT application up to version 4.0.2, the web interface hides SSH secrets, Windows passwords, and SNMP strings from users using HTML 'password field' obfuscation. By using Developer tools or similar, it is possible to change the obfuscation so that the credentials are visible.
 
 [Vulnerability Type]
 
@@ -15,7 +15,7 @@ Open-AudIT by Opmantek
 
 [Affected Product Code Base]
 
-Open-AudIT up to version 3.5.3.
+Open-AudIT up to version 4.0.2.
 
 [Attack Type]
 


### PR DESCRIPTION
With 232d60f69844d49ad38c0857989914dd819d652c the affected version got changed from `up to 3.5.3` to `up to 4.0.2` but this part was missed.

This should avoid confusion as two different affected versions are currently mentioned.